### PR TITLE
Added functionality to match json objects while ignoring keys

### DIFF
--- a/spec/match_golden_spec.rb
+++ b/spec/match_golden_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe 'RSpec::Matchers::Golden::match_golden' do
     end
   end
 
+  context 'when comparing with JsonFormatter' do
+    it 'can compare hashes and arrays as json' do
+      expect({fox: ['quick', 'brown'], dog: 'lazy'}).to match_golden_json('gold/json_structs.json')
+    end
+
+    it 'can compare hashes and arrays as json excluding keys' do
+      expect({id: 20, fox: ['quick', 'brown'], dog: 'lazy'}).to(
+        match_golden_json('gold/json_structs.json', excluded: [:id])
+      )
+    end
+  end
+
   context 'when recording' do
     before do
       @golden = ENV[RSpec::Matchers::Golden::GOLDEN_ENV]


### PR DESCRIPTION
Hi! First, thanks for putting this gem together!!

I found myself wanting this functionality in the gem, thats why I forked the project and added it. You can argue that the interface provided is good enough to let me have the formatter as part of my project so I leave this PR in your hands.

If you decide to merge it I can add some documentation around the new matcher.